### PR TITLE
CI: run on ubuntu-latest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         backend: ["SERIAL", "OPENMP"]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ghcr.io/ecp-copa/ci-containers/ubuntu:latest
     steps:
       - name: Checkout kokkos


### PR DESCRIPTION
20.04 is being retired; avoid having to do this in the future with latest
